### PR TITLE
Add custom GOPATH setting

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,6 +24,17 @@ class Gotype(Linter):
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     error_stream = util.STREAM_STDERR
 
+    def __init__(self, view, syntax):
+        """Initialize and load GOPATH from settings if present."""
+        super(Gotype, self).__init__(view, syntax)
+
+        gopath = self.get_view_settings().get('gopath')
+        if gopath:
+            if self.env:
+                self.env['GOPATH'] = gopath
+            else:
+                self.env = {'GOPATH': gopath}
+
     def run(self, cmd, code):
         """Copy package files to temp dir."""
         files = [f for f in listdir(dirname(self.filename)) if f[-3:] == '.go']


### PR DESCRIPTION
When vendoring dependencies, the linter needs to use a different GOPATH for each project. I've added an optional 'gopath' setting, which can now be set in a `.sublime-project` file:

``` json
{
    "SublimeLinter": {
        "linters": {
            "gotype": {
                "gopath": "/custom/go/path:/another/go/path"
            }
        }
    }
}
```

Let me know what you think, thanks for the good work.
